### PR TITLE
refactor: use env variable for backend URL

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+.env
 
 # Editor directories and files
 .vscode/*

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,7 +11,9 @@ function App() {
   async function fetchWeather() {
     if (!city) return;
     try {
-      const respone = await fetch(`http://localhost:3001/weather?city=${city}`);
+      const respone = await fetch(
+        `${import.meta.env.BACKEND_URL}/weather?city=${city}`
+      );
       if (!respone.ok) throw new Error({ error: "The city cannot be found." });
       const weatherData = await respone.json();
       setWeatherData(weatherData);


### PR DESCRIPTION
Removed hardcoded localhost URL and replaced with BACKEND_URL for easier deployment and environment separation.